### PR TITLE
issue #3: fix issue with data not being saved correctly

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Upgrade hook.
+ *
+ * @package     profilefield_autocomplete
+ * @author      Dmitrii Metelkin <dnmetelk@gmail.com>
+ * @copyright   Dmitrii Metelkin <dnmetelk@gmail.com>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Upgrade the plugin.
+ *
+ * @param int $oldversion The old version of the plugin
+ * @return bool
+ */
+function xmldb_profilefield_autocomplete_upgrade($oldversion): bool {
+    global $DB, $CFG;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2022071901) {
+        require_once($CFG->dirroot . '/user/profile/lib.php');
+        require_once($CFG->dirroot . '/user/profile/field/autocomplete/field.class.php');
+
+        // We would like to update only autocomplete fields with multiple values.
+        $select = "datatype = 'autocomplete' AND param2 = '1'";
+        $fields = $DB->get_records_select('user_info_field', $select);
+
+        if ($fields) {
+            list($fieldssql, $params) = $DB->get_in_or_equal(array_keys($fields), SQL_PARAMS_NAMED);
+            $params['search'] = $search = ', '; // Old broken delimiter.
+            $params['replace'] = profile_field_autocomplete::DELIMITER; // New delimiter.
+            $params['searchparam'] = '%'.$DB->sql_like_escape($search).'%';
+
+            $searchsql = $DB->sql_like('data', ':searchparam');
+
+            $sql = "UPDATE {user_info_data}
+                       SET data = REPLACE(data, :search, :replace)
+                     WHERE $searchsql AND fieldid $fieldssql";
+
+            $DB->execute($sql, $params);
+        }
+
+        upgrade_plugin_savepoint(true, 2022071901, 'profilefield', 'autocomplete');
+    }
+
+    return true;
+}

--- a/field.class.php
+++ b/field.class.php
@@ -23,6 +23,12 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class profile_field_autocomplete extends profile_field_base {
+
+    /**
+     * Unique values delimiter for storing values as a string in DB.
+     */
+    public const DELIMITER = '#||#';
+
     /** @var array $options */
     public $options;
 
@@ -68,7 +74,7 @@ class profile_field_autocomplete extends profile_field_base {
 
         // Set the data key.
         if ($this->data !== null) {
-            $this->datakey = explode(', ', $this->data);
+            $this->datakey = explode(self::DELIMITER, $this->data);
         }
     }
 
@@ -82,6 +88,7 @@ class profile_field_autocomplete extends profile_field_base {
         $mform->addElement('autocomplete', $this->inputname, format_string($this->field->name), $this->options, [
             'multiple' => $this->multiple
         ]);
+        $mform->setType($this->inputname, PARAM_TEXT);
     }
 
     /**
@@ -127,7 +134,7 @@ class profile_field_autocomplete extends profile_field_base {
         }
 
         // Convert values into string to store it in database.
-        return implode(', ', $data);
+        return implode(self::DELIMITER, $data);
     }
 
     /**
@@ -203,5 +210,15 @@ class profile_field_autocomplete extends profile_field_base {
      */
     public function get_field_properties() {
         return array(PARAM_TEXT, NULL_NOT_ALLOWED);
+    }
+
+    /**
+     * Display the data for this field
+     * @return string
+     */
+    public function display_data() {
+        $options = new stdClass();
+        $options->para = false;
+        return format_text(str_replace(self::DELIMITER, ', ', $this->data), FORMAT_MOODLE, $options);
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,6 +25,6 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022071900;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022071901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2020060900;        // Requires this Moodle version.
 $plugin->component = 'profilefield_autocomplete'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Testing instructions

Prerequsite 
1. Add autocomplete field with multiple options and multiple values allowed. Make sure that one of the values is "Test, option, with commas and space, "
2. Create few users and poupulate data of the just created field.
3. **Confirm** selected values are all displayed correctly on users profile pages, except "Test, option, with commas and space, ".
4. Apply patch and run upgrade script php admin/cli/upgrade.php or finish upgrade through UI.
5. **Confirm** all previusly set values are all displayed correctly on users profile pages.
6. Update one or more users, add/remove values for autocomplete field. **Confirm** it all works as expected and values are saved and displayed on user profile pages. 
7. Make sure you use "Test, option, with commas and space, " option when save values. **Confirm** that now this value is saved and displayed correctly.