### PR TITLE
issue #5: fix issue with displaying locked field

### DIFF
--- a/field.class.php
+++ b/field.class.php
@@ -156,7 +156,7 @@ class profile_field_autocomplete extends profile_field_base {
 
         if ($this->is_locked() and !has_capability('moodle/user:update', context_system::instance())) {
             $mform->hardFreeze($this->inputname);
-            $mform->setConstant($this->inputname, format_string($this->datakey));
+            $mform->setConstant($this->inputname, format_string($this->data));
         }
     }
 


### PR DESCRIPTION
Fixes #5 

This patch fixes the issue when incorrect parameter was sent to format_string function in case when the field is locked and needs to be frozen.  